### PR TITLE
feat(answerGroupId): adding answer_group_id in reponse of post questi…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+What are changes related to ?
+
+# Linked Issues
+What are the issues fixed by this pull request ?
+
+# Changes
+What does it change ?
+Is is a breaking change ?
+Is is a new feature ?
+Is is a patch, fix, hotfix ?
+
+# Screenshots
+Put screenshots (if any)
+
+# Tests
+How has it been tested ?
+
+- [ ] Manually
+- [ ] Automated tests
+- [ ] QA
+- [ ] Other
+
+# Additional information
+Precise any other information

--- a/plugins/xpeapp-backend/src/qvst/questions/post_questions_answers.php
+++ b/plugins/xpeapp-backend/src/qvst/questions/post_questions_answers.php
@@ -20,6 +20,7 @@ function api_post_qvst_answers(WP_REST_Request $request)
 	// List of parameters
 	$campaign_id = $params['id'];
 	$user_id = $request->get_header('userId');
+	$token = $request->get_header('Authorization');
 
 	if (empty($params) || empty($body)) {
 		return new WP_Error('noParams', __('No parameters or body', 'QVST'));
@@ -66,6 +67,7 @@ function api_post_qvst_answers(WP_REST_Request $request)
 						'campaign_id' => $campaign_id,
 						'question_id' => $question->id,
 						'answer_id' => $answer->id,
+						'answer_group_id' => $token,
 					)
 				);
 			}


### PR DESCRIPTION
…ons answers

# Description
In order of this [ticket](https://github.com/XPEHO/xpeapp_backend/issues/19) we need to modify the endpoint who send the answers of campaign. At the place of column answer_group_id we put the bearer token of the user.

# Changes
What does it change ? It change the response in the database 
Is is a breaking change ?
Is is a new feature ?
Is is a patch, fix, hotfix ?

# Screenshots

FAKE DATA :
<img width="732" alt="image" src="https://github.com/user-attachments/assets/c081894d-f714-491e-9639-ac274f77ae4b" />

# Tests
How has it been tested ?

- [X] Manually
- [X] Connect with front end app

# Additional information
Precise any other information
