### PR TITLE
chore(deploy): create deployment CD

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,21 @@
+name: Deploy backend
+
+on:
+  workflow_dispatch:
+    inputs:
+      comment:
+        description: 'Comment for the deployment'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update and restart
+        uses: garygrossgarten/github-action-ssh@0.8.0
+        with:
+          command: sh update_xpeapp.sh
+          host: ${{ secrets.XPEHO_SERVER_IP }}
+          username: debian
+          passphrase: ${{ secrets.XPEHO_SSH_PASS }}
+          privateKey: ${{ secrets.XPEHO_SSH_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ You copy the token field and paste it in the header of the request as follows:
 
 After every merge to the main branch, a docker image will be created in packages, you can see it on the package section at the right of the code page of the repository.
 
+### Use Github action to deploy
+
+You can use the Github action to deploy the project on your server. See [deploy workflow](.github/workflows/deploy.yaml).
+
+1. Open the Github repository page
+2. Go to the 'Actions' tab
+3. Click on the 'Deploy' workflow
+4. Click on the 'Run workflow' button
+5. Fill the form with the comment and click on the 'Run workflow' button
+
+### Deploy manually on the server
+
 Now you can pull the docker image (on your server for instance) using :
 
 ```shell


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of the backend. The most important changes include the addition of a new workflow file, configuration for triggering the workflow, and steps to execute the deployment process.

New GitHub Actions workflow:

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R1-R24): Added a new workflow named "Deploy backend" that triggers on pushes to the `chore/deploy` branch and can also be manually triggered with a comment input. The workflow includes a job that runs on `ubuntu-latest` and uses an SSH action to update and restart the application on the server.